### PR TITLE
:ambulance: use index.ts to create type definitions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "lib": ["esnext", "dom"],
     "types": ["vite/client"]
   },
-  "include": ["src/services/*.ts"]
+  "include": ["index.ts"]
 }


### PR DESCRIPTION
Wrongly exported type definitions \o/